### PR TITLE
Fixes #12606: Validates repo ids on enable/disable -r commands

### DIFF
--- a/lib/disconnected_pulp.rb
+++ b/lib/disconnected_pulp.rb
@@ -76,11 +76,18 @@ class DisconnectedPulp
   end
 
   def enable(value, repoids = nil, all = nil)
+    allrepoids = manifest.repositories.keys
     if repoids
       repoids = repoids.split(/,\s*/).collect(&:strip)
+      # Check all given repos are valid
+      repoids.each do |repoid|
+        unless allrepoids.include?(repoid)
+          LOG.error _("%{repoid} isn't listed in the imported manifest, see katello-disconnected list --disabled") % {:repoid => repoid}
+        end
+      end
     else
       if all
-        repoids = manifest.repositories.keys
+        repoids = allrepoids
       else
         LOG.error _('You need to provide some repoids')
         return


### PR DESCRIPTION
I know this is going to be replaced with a "inter satellite link" at some point but I made this change to my install as i kept thinking I had enabled a repo but after a configure the repo wasn't listed.
